### PR TITLE
Lockscreen charging info: real time values [2/4]

### DIFF
--- a/healthd/BatteryMonitor.cpp
+++ b/healthd/BatteryMonitor.cpp
@@ -37,6 +37,10 @@
 
 #define POWER_SUPPLY_SUBSYSTEM "power_supply"
 #define POWER_SUPPLY_SYSFS_PATH "/sys/class/" POWER_SUPPLY_SUBSYSTEM
+#ifdef BATTERY_REAL_INFO
+#define SYSFS_BATTERY_CURRENT "/sys/class/power_supply/battery/current_now"
+#define SYSFS_BATTERY_VOLTAGE "/sys/class/power_supply/battery/voltage_now"
+#endif
 #define FAKE_BATTERY_CAPACITY 42
 #define FAKE_BATTERY_TEMPERATURE 424
 #define ALWAYS_PLUGGED_CAPACITY 100
@@ -348,6 +352,15 @@ bool BatteryMonitor::update(void) {
                                              name);
                             }
 
+#ifdef BATTERY_REAL_INFO
+                 int ChargingCurrent =
+                      (access(SYSFS_BATTERY_CURRENT, R_OK) == 0) ? abs(getIntField(String8(SYSFS_BATTERY_CURRENT))) : 0;
+
+                int ChargingVoltage =
+                      (access(SYSFS_BATTERY_VOLTAGE, R_OK) == 0) ? getIntField(String8(SYSFS_BATTERY_VOLTAGE)) :
+                       DEFAULT_VBUS_VOLTAGE;
+#else
+
                             //If its online, read the voltage and current for power
                             path.clear();
                             path.appendFormat("%s/%s/current_max", POWER_SUPPLY_SYSFS_PATH,
@@ -362,6 +375,7 @@ bool BatteryMonitor::update(void) {
                             int ChargingVoltage =
                               (access(path.string(), R_OK) == 0) ? getIntField(path) :
                               DEFAULT_VBUS_VOLTAGE;
+#endif
 
                             double power = ((double)ChargingCurrent / MILLION) *
                                     ((double)ChargingVoltage / MILLION);


### PR DESCRIPTION
Use current_now and voltage_now instead current_max and voltage_max.
*To enable this:
BOARD_GLOBAL_CFLAGS += -DBATTERY_REAL_INFO

(need to add the BOARD_GLOBAL_CFLAGS call in the build tree)

in the device BoardConfig

Change-Id: Ic074b96062b8f3def4bed9f9a30daae93eb075e9